### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+# Run docker-compose up from postgres directory
+run:
+	cd postgres && docker-compose up -d
+
+# Stop and remove containers from postgres directory
+stop:
+	cd postgres && docker-compose down
+
+# View logs of running containers
+logs:
+	cd postgres && docker-compose logs -f
+
+# List running containers
+ps:
+	cd postgres && docker-compose ps
+
+# Access PostgreSQL shell
+psql:
+	cd postgres && docker-compose exec database psql -U induwara -d initial_db
+
+# Rebuild containers
+build:
+	cd postgres && docker-compose build
+
+# Clean up volumes and networks (full cleanup)
+clean:
+	cd postgres && docker-compose down -v --remove-orphans
+	rm -rf postgres/db-data
+	rm -rf postgres/pgadmin-data
+    
+# Restart containers
+restart:
+	cd postgres && docker-compose restart

--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -1,3 +1,6 @@
+-- Connect to the database
+\c initial_db;
+
 -- create a table for user information
 CREATE TABLE users (
   id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,


### PR DESCRIPTION
This pull request introduces a set of new `Makefile` commands for managing PostgreSQL containers using `docker-compose` and an initialization script for connecting to the database in the `postgres/init.sql` file.

Makefile enhancements for PostgreSQL management:

* Added commands to run, stop, view logs, list containers, access PostgreSQL shell, rebuild containers, clean up volumes and networks, and restart containers using `docker-compose` within the `postgres` directory.

Database initialization script update:

* Modified `postgres/init.sql` to include a command for connecting to the `initial_db` database.